### PR TITLE
Add drag-and-drop task prioritization

### DIFF
--- a/components/task_reorder/index.html
+++ b/components/task_reorder/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Task Reorder</title>
+    <script src="https://unpkg.com/streamlit-component-lib/dist/index.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+      }
+
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      li {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.65rem 0.85rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(128, 128, 128, 0.35);
+        background: rgba(255, 255, 255, 0.75);
+        backdrop-filter: blur(6px);
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+        cursor: grab;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+      }
+
+      li:active {
+        cursor: grabbing;
+        transform: scale(1.01);
+        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+      }
+
+      li .title {
+        flex: 1 1 auto;
+        font-size: 0.95rem;
+        line-height: 1.4;
+        word-break: break-word;
+      }
+
+      li.done .title {
+        text-decoration: line-through;
+        opacity: 0.55;
+      }
+
+      li .handle {
+        font-size: 1.2rem;
+        opacity: 0.55;
+        user-select: none;
+      }
+
+      .drag-ghost {
+        opacity: 0.4;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        li {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <ul id="task-items"></ul>
+    <script>
+      const root = document.getElementById("task-items");
+      let sortable = null;
+      let currentValue = [];
+
+      function emitOrder() {
+        const order = Array.from(root.children).map((child) =>
+          Number(child.dataset.taskId)
+        );
+        const snapshot = JSON.stringify(order);
+        if (JSON.stringify(currentValue) !== snapshot) {
+          currentValue = order;
+          window.Streamlit.setComponentValue(order);
+        }
+        window.Streamlit.setFrameHeight(root.scrollHeight + 8);
+      }
+
+      function renderItems(items) {
+        const existingIds = Array.from(root.children).map(
+          (child) => Number(child.dataset.taskId)
+        );
+        const nextIds = items.map((item) => item.id);
+        const shouldRebuild =
+          existingIds.length !== nextIds.length ||
+          existingIds.some((value, index) => value !== nextIds[index]);
+
+        if (shouldRebuild) {
+          root.innerHTML = "";
+          items.forEach((item) => {
+            const li = document.createElement("li");
+            li.dataset.taskId = String(item.id);
+            if (item.done) {
+              li.classList.add("done");
+            }
+
+            const handle = document.createElement("span");
+            handle.className = "handle";
+            handle.textContent = "⋮⋮";
+
+            const title = document.createElement("span");
+            title.className = "title";
+            title.textContent = item.title;
+
+            li.appendChild(handle);
+            li.appendChild(title);
+            root.appendChild(li);
+          });
+
+          if (sortable) {
+            sortable.destroy();
+          }
+
+          sortable = new Sortable(root, {
+            animation: 150,
+            ghostClass: "drag-ghost",
+            handle: ".handle",
+            onEnd: emitOrder,
+          });
+        } else {
+          Array.from(root.children).forEach((child) => {
+            const item = items.find(
+              (candidate) => String(candidate.id) === child.dataset.taskId
+            );
+            if (!item) {
+              return;
+            }
+            child.classList.toggle("done", Boolean(item.done));
+            const titleNode = child.querySelector(".title");
+            if (titleNode && titleNode.textContent !== item.title) {
+              titleNode.textContent = item.title;
+            }
+          });
+        }
+
+        emitOrder();
+      }
+
+      window.Streamlit.events.addEventListener(
+        window.Streamlit.RENDER_EVENT,
+        (event) => {
+          const { items } = event.detail.args;
+          renderItems(items ?? []);
+        }
+      );
+
+      window.Streamlit.setComponentReady();
+    </script>
+  </body>
+</html>

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -6,7 +6,12 @@ from typing import Callable
 
 import pytest
 
-from todo import InMemoryTaskRepository, SQLiteTaskRepository, Task, TaskRepository
+from todo import (
+    InMemoryTaskRepository,
+    SQLiteTaskRepository,
+    Task,
+    TaskRepository,
+)
 
 
 RepoFactory = Callable[[], TaskRepository]
@@ -66,6 +71,34 @@ def test_remove_task_drops_only_target(repo: TaskRepository) -> None:
 
     remaining_ids = [task.id for task in repo.list_tasks()]
     assert remaining_ids == [one.id, three.id]
+
+
+def test_tasks_are_returned_in_position_order(repo: TaskRepository) -> None:
+    first = repo.add("ship")
+    second = repo.add("test")
+    third = repo.add("deploy")
+
+    assert first is not None and second is not None and third is not None
+
+    titles = [task.title for task in repo.list_tasks()]
+    assert titles == ["ship", "test", "deploy"]
+
+    positions = [task.position for task in repo.list_tasks()]
+    assert positions == [0, 1, 2]
+
+
+def test_reorder_updates_positions(repo: TaskRepository) -> None:
+    first = repo.add("ship")
+    second = repo.add("test")
+    third = repo.add("deploy")
+
+    assert first is not None and second is not None and third is not None
+
+    repo.reorder([third.id, first.id, second.id])
+
+    tasks = repo.list_tasks()
+    assert [task.title for task in tasks] == ["deploy", "ship", "test"]
+    assert [task.position for task in tasks] == [0, 1, 2]
 
 
 def test_completion_stats_counts_done_tasks(repo: TaskRepository) -> None:

--- a/todo.py
+++ b/todo.py
@@ -11,6 +11,7 @@ class Task:
     id: int
     title: str
     done: bool = False
+    position: int = 0
 
 
 TaskId = int
@@ -27,6 +28,8 @@ class TaskRepository(Protocol):
     def remove(self, task_id: TaskId) -> None: ...
 
     def completion_stats(self) -> tuple[int, int]: ...
+
+    def reorder(self, ordered_ids: list[TaskId]) -> TaskList: ...
 
 
 def _normalise_title(title: str) -> str:
@@ -46,7 +49,11 @@ class InMemoryTaskRepository:
         if not normalised:
             return None
 
-        task = Task(id=self._next_id, title=normalised)
+        task = Task(
+            id=self._next_id,
+            title=normalised,
+            position=len(self._tasks),
+        )
         self._tasks.append(task)
         self._next_id += 1
         return task
@@ -61,11 +68,31 @@ class InMemoryTaskRepository:
 
     def remove(self, task_id: TaskId) -> None:
         self._tasks = [task for task in self._tasks if task.id != task_id]
+        self._reindex_positions()
 
     def completion_stats(self) -> tuple[int, int]:
         total = len(self._tasks)
         done = sum(task.done for task in self._tasks)
         return int(done), total
+
+    def reorder(self, ordered_ids: list[TaskId]) -> TaskList:
+        if len(ordered_ids) != len(self._tasks):
+            raise ValueError("ordered_ids must include every task exactly once")
+
+        id_to_task = {task.id: task for task in self._tasks}
+        if set(ordered_ids) != set(id_to_task):
+            raise ValueError("ordered_ids must include every task exactly once")
+
+        self._tasks = [
+            replace(id_to_task[task_id], position=index)
+            for index, task_id in enumerate(ordered_ids)
+        ]
+        return self.list_tasks()
+
+    def _reindex_positions(self) -> None:
+        self._tasks = [
+            replace(task, position=index) for index, task in enumerate(self._tasks)
+        ]
 
 
 class SQLiteTaskRepository:
@@ -76,7 +103,7 @@ class SQLiteTaskRepository:
 
     def list_tasks(self) -> TaskList:
         cursor = self._connection.execute(
-            "SELECT id, title, done FROM tasks ORDER BY id"
+            "SELECT id, title, done, position FROM tasks ORDER BY position, id"
         )
         rows = cursor.fetchall()
         return [self._row_to_task(row) for row in rows]
@@ -86,17 +113,22 @@ class SQLiteTaskRepository:
         if not normalised:
             return None
 
+        next_position_row = self._connection.execute(
+            "SELECT COALESCE(MAX(position), -1) + 1 AS next_position FROM tasks"
+        ).fetchone()
+        next_position = int(next_position_row["next_position"])
+
         cursor = self._connection.execute(
-            "INSERT INTO tasks (title, done) VALUES (?, 0)",
-            (normalised,),
+            "INSERT INTO tasks (title, done, position) VALUES (?, 0, ?)",
+            (normalised, next_position),
         )
         self._connection.commit()
         task_id = cursor.lastrowid
-        return Task(id=task_id, title=normalised, done=False)
+        return Task(id=task_id, title=normalised, done=False, position=next_position)
 
     def toggle(self, task_id: TaskId) -> Task:
         row = self._connection.execute(
-            "SELECT id, title, done FROM tasks WHERE id = ?",
+            "SELECT id, title, done, position FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if row is None:
@@ -108,11 +140,17 @@ class SQLiteTaskRepository:
             (new_done, task_id),
         )
         self._connection.commit()
-        return Task(id=row["id"], title=row["title"], done=bool(new_done))
+        return Task(
+            id=row["id"],
+            title=row["title"],
+            done=bool(new_done),
+            position=row["position"],
+        )
 
     def remove(self, task_id: TaskId) -> None:
         self._connection.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
         self._connection.commit()
+        self._normalise_positions()
 
     def completion_stats(self) -> tuple[int, int]:
         row = self._connection.execute(
@@ -122,18 +160,95 @@ class SQLiteTaskRepository:
         done = int(row["done"])
         return done, total
 
+    def reorder(self, ordered_ids: list[TaskId]) -> TaskList:
+        existing_rows = self._connection.execute(
+            "SELECT id, position FROM tasks ORDER BY position, id"
+        ).fetchall()
+        existing_ids = [row["id"] for row in existing_rows]
+
+        if len(existing_ids) != len(ordered_ids):
+            raise ValueError("ordered_ids must include every task exactly once")
+
+        if set(existing_ids) != set(ordered_ids):
+            raise ValueError("ordered_ids must include every task exactly once")
+
+        max_position = max((int(row["position"]) for row in existing_rows), default=-1)
+        offset_base = max_position + 1
+        temp_updates = [
+            (offset_base + index, task_id)
+            for index, task_id in enumerate(ordered_ids)
+        ]
+        final_updates = [
+            (index, task_id) for index, task_id in enumerate(ordered_ids)
+        ]
+        self._connection.executemany(
+            "UPDATE tasks SET position = ? WHERE id = ?",
+            temp_updates,
+        )
+        self._connection.executemany(
+            "UPDATE tasks SET position = ? WHERE id = ?",
+            final_updates,
+        )
+        self._connection.commit()
+        return self.list_tasks()
+
     def _initialise(self) -> None:
         self._connection.execute(
             """
             CREATE TABLE IF NOT EXISTS tasks (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 title TEXT NOT NULL,
-                done INTEGER NOT NULL DEFAULT 0 CHECK(done IN (0, 1))
+                done INTEGER NOT NULL DEFAULT 0 CHECK(done IN (0, 1)),
+                position INTEGER NOT NULL UNIQUE
             )
             """
         )
         self._connection.commit()
+        self._ensure_position_column()
+        self._normalise_positions()
 
     @staticmethod
     def _row_to_task(row: Row) -> Task:
-        return Task(id=row["id"], title=row["title"], done=bool(row["done"]))
+        return Task(
+            id=row["id"],
+            title=row["title"],
+            done=bool(row["done"]),
+            position=int(row["position"]),
+        )
+
+    def _ensure_position_column(self) -> None:
+        columns = self._connection.execute("PRAGMA table_info(tasks)").fetchall()
+        has_position = any(column["name"] == "position" for column in columns)
+        if not has_position:
+            self._connection.execute("ALTER TABLE tasks ADD COLUMN position INTEGER")
+            self._connection.commit()
+            self._connection.execute("UPDATE tasks SET position = id")
+            self._connection.commit()
+        self._connection.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_position ON tasks(position)"
+        )
+        self._connection.commit()
+
+    def _normalise_positions(self) -> None:
+        rows = self._connection.execute(
+            "SELECT id, position FROM tasks ORDER BY position, id"
+        ).fetchall()
+        ids = [row["id"] for row in rows]
+        if not ids:
+            return
+
+        max_position = max((int(row["position"]) for row in rows), default=-1)
+        offset_base = max_position + 1
+        temp_updates = [
+            (offset_base + index, task_id) for index, task_id in enumerate(ids)
+        ]
+        final_updates = [(index, task_id) for index, task_id in enumerate(ids)]
+        self._connection.executemany(
+            "UPDATE tasks SET position = ? WHERE id = ?",
+            temp_updates,
+        )
+        self._connection.executemany(
+            "UPDATE tasks SET position = ? WHERE id = ?",
+            final_updates,
+        )
+        self._connection.commit()


### PR DESCRIPTION
## Summary
- add a reusable Streamlit component that allows dragging tasks to set their priority order
- persist task ordering in both in-memory and SQLite repositories with new reorder APIs
- cover the ordering behaviour with repository tests

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3128be40c8330866bdcf58d858d41